### PR TITLE
add say what you see question type

### DIFF
--- a/QuizExperiment.Admin/Client/Pages/Tests/Client/SayWhatYouSee.razor
+++ b/QuizExperiment.Admin/Client/Pages/Tests/Client/SayWhatYouSee.razor
@@ -1,0 +1,19 @@
+﻿@page "/test/client/saywhatyouee"  
+@using QuizModels = QuizExperiment.Models.Client  
+@layout QuizExperiment.Admin.Client.Shared.Client.Layout
+
+<QuizExperiment.Admin.Client.Shared.Client.SayWhatYouSeeQuestion Question="@_currentQuestion"  
+OnAnswerSubmit="@AnswerQuestion" />  
+
+@code {  
+    private QuizModels.ClientSayWhatYouSeeQuestion _currentQuestion = new QuizModels.ClientSayWhatYouSeeQuestion
+    {  
+        Title = "This is a test Question, it goes on a bit, in fact it goes on for ages and ages and ages",    
+        ImageUrl = "https://placehold.co/600x400"
+    };  
+
+    private void AnswerQuestion(QuizModels.ClientAnswer answer)
+    {
+        Console.WriteLine($"User answered: {answer}");  
+    }  
+}

--- a/QuizExperiment.Admin/Client/Pages/Tests/Client/SayWhatYouSeeAnswerSummary.razor
+++ b/QuizExperiment.Admin/Client/Pages/Tests/Client/SayWhatYouSeeAnswerSummary.razor
@@ -1,0 +1,39 @@
+﻿@page "/test/client/answersummary/saywhatyousee"  
+@using QuizModels = QuizExperiment.Models.Client
+@layout QuizExperiment.Admin.Client.Shared.Client.Layout
+
+<QuizExperiment.Admin.Client.Shared.Client.AnswerSummary   MyAnswer="@myAnswer"
+                                                                Question="@question"
+                                                                IsLastQuestion="false"
+                                                                CorrectAnswer="@correctAnswer"
+                                                                CurrentScore="0"
+                                                                Position="1"
+/>
+
+@code {
+    QuizModels.ClientSayWhatYouSeeAnswer myAnswer = new QuizModels.ClientSayWhatYouSeeAnswer
+    {
+        Answers = new List<string>
+        {
+            "Dog"
+        }
+    };
+
+    QuizModels.ClientSayWhatYouSeeQuestion question = new QuizModels.ClientSayWhatYouSeeQuestion
+    {
+        Title = "This is a test Question, it goes on a bit, in fact it goes on for ages and ages and ages",
+        ImageUrl = "https://imgur.com/NkMONh3",
+        
+    };
+
+    QuizModels.ClientSayWhatYouSeeAnswer correctAnswer = new QuizModels.ClientSayWhatYouSeeAnswer
+    {
+        Answers = new List<string>
+        {
+            "One",
+            "Two",
+            "Three"
+        }
+    };
+
+}

--- a/QuizExperiment.Admin/Client/Pages/Tests/Present/SayWhatYouSee.razor
+++ b/QuizExperiment.Admin/Client/Pages/Tests/Present/SayWhatYouSee.razor
@@ -1,0 +1,21 @@
+﻿@page "/test/present/saywhatyouee"  
+@using QuizModels = QuizExperiment.Models  
+@layout QuizExperiment.Admin.Client.Shared.Client.Layout
+
+<QuizExperiment.Admin.Client.Shared.Present.SayWhatYouSeeQuestion Question="@_currentQuestion" QuestionEndTime="@QuestionEndTime" UserAnswerCount="@UserAnswerCount" />
+
+@code {  
+
+    private DateTime QuestionEndTime => DateTime.Now.AddMinutes(10);
+    private int UserAnswerCount => 0; // Placeholder for user answer count
+    private QuizModels.SayWhatYouSeeQuestion _currentQuestion = new QuizModels.SayWhatYouSeeQuestion
+    {  
+        Title = "This is a test Question, it goes on a bit, in fact it goes on for ages and ages and ages",    
+        ImageUrl = "https://placehold.co/600x400"
+    };  
+
+    private void AnswerQuestion(QuizModels.Client.ClientAnswer answer)
+    {
+        Console.WriteLine($"User answered: {answer}");
+    }  
+}

--- a/QuizExperiment.Admin/Client/Shared/Client/QuestionPicker.razor
+++ b/QuizExperiment.Admin/Client/Shared/Client/QuestionPicker.razor
@@ -15,6 +15,10 @@
         {
             <TrueFalseQuestion Question="@trueFalseQuestion" OnAnswerSubmit="@OnAnswerSubmit" />
         }
+        else if(Question is ClientSayWhatYouSeeQuestion sayWhatYouSeeQuestion)
+        {
+            <SayWhatYouSeeQuestion Question="@sayWhatYouSeeQuestion" OnAnswerSubmit="@OnAnswerSubmit" />
+        }
         else
         {
             <p class="text-warning">Unsupported question type.</p>

--- a/QuizExperiment.Admin/Client/Shared/Client/SayWhatYouSeeQuestion.razor
+++ b/QuizExperiment.Admin/Client/Shared/Client/SayWhatYouSeeQuestion.razor
@@ -1,0 +1,34 @@
+@using QuizExperiment.Models.Client
+
+@{
+    if(Question != null)
+    {
+        <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center quiz-page">
+            <h1 class="h1 text-center px-3">@Question.Title</h1>
+            <img class="img-fluid rounded img-quiz my-3 px-3" src="@Question.ImageUrl" />
+            <div class="quiz-button-container swys-container d-flex flex-column align-items-center w-100 px-3" style="max-width: 400px;">
+                <input type="text" class="form-control quiz-edit-question-input-answer mb-2" placeholder="Type your answer..." @bind="UserAnswer" @bind:event="oninput" id="userAnswerInput" />
+                <button class="btn btn-success btn-primary-action w-100" @onclick="SubmitAnswer">Submit</button>
+            </div>
+        </div>
+    }
+}
+
+@code {
+    [Parameter]
+    public ClientSayWhatYouSeeQuestion? Question { get; set; }
+
+    [Parameter]
+    public EventCallback<ClientAnswer> OnAnswerSubmit { get; set; }
+
+    private string UserAnswer { get; set; } = string.Empty;
+
+    private async Task SubmitAnswer()
+    {
+        var answer = new ClientSayWhatYouSeeAnswer
+        {
+            Answers = new List<string> { UserAnswer }
+        };
+        await OnAnswerSubmit.InvokeAsync(answer);
+    }
+}

--- a/QuizExperiment.Admin/Client/Shared/Edit/QuestionTypePickerModal.razor
+++ b/QuizExperiment.Admin/Client/Shared/Edit/QuestionTypePickerModal.razor
@@ -22,6 +22,12 @@
                                 <span>True / False</span>
                             </button>
                         </div>
+                        <div class="text-center">
+                            <button class="btn btn-outline-success" @onclick="SayWhatYouSeeClicked">
+                                <span class="oi oi-pencil" style="font-size:2rem;"></span><br />
+                                <span>Type the Answer</span>
+                            </button>
+                        </div>
                     </div>
                     <div class="modal-footer bg-light">
                         <button type="button" class="btn btn-secondary" @onclick="Cancel">Cancel</button>
@@ -48,6 +54,10 @@
     private async Task TrueFalseClicked()
     {
         await SelectType("trueFalse");
+    }
+    private async Task SayWhatYouSeeClicked()
+    {
+        await SelectType("sayWhatYouSee");
     }
     private async Task SelectType(string type)
     {

--- a/QuizExperiment.Admin/Client/Shared/Edit/RootComponent.razor
+++ b/QuizExperiment.Admin/Client/Shared/Edit/RootComponent.razor
@@ -83,6 +83,10 @@
                         {
                             <TrueFalseQuestion Question="_currentQuestion" />
                         }
+                        else if (_currentQuestion is QuizModels.SayWhatYouSeeQuestion)
+                        {
+                            <SayWhatYouSeeQuestion Question="_currentQuestion" />
+                        }
                         else
                         {
                             <div class="d-flex flex-column align-items-center">
@@ -133,27 +137,30 @@
 
     private void OnAddQuestion(string questionType)
     {
-        Question newQuestion;
-        if (questionType == "trueFalse")
+        Question newQuestion = questionType switch
         {
-            newQuestion = new QuizModels.TrueFalseQuestion()
+            "trueFalse" => new QuizModels.TrueFalseQuestion()
             {
                 Timeout = 20,
                 ImageUrl = "",
                 Title = ""
-            };
-        }
-        else // default to multipleChoice
-        {
-            newQuestion = new QuizModels.MultipleChoiceQuestion()
+            },
+            "sayWhatYouSee" => new QuizModels.SayWhatYouSeeQuestion()
+            {
+                Timeout = 40,
+                ImageUrl = "",
+                Title = "",
+                // Add any other default properties for SayWhatYouSeeQuestion here
+            },
+            _ => new QuizModels.MultipleChoiceQuestion()
             {
                 Options = new[] {"","","",""},
                 Timeout = 20,
                 ImageUrl = "",
                 Title = "",
                 CorrectAnswerIndex = -1
-            };
-        }
+            }
+        };
         _questions.Add(newQuestion);
         _currentQuestion = newQuestion;
     }

--- a/QuizExperiment.Admin/Client/Shared/Edit/RootComponent.razor
+++ b/QuizExperiment.Admin/Client/Shared/Edit/RootComponent.razor
@@ -231,13 +231,18 @@
 
     private async Task SaveAndPresent()
     {
+        var query_string = "";
+        if (!string.IsNullOrWhiteSpace(FolderPath))
+        {
+            query_string = "?path=" + FolderPath;
+        }
         if (!AreAllQuestionsValid)
         {
             ShowValidationAlertMessage();
             return;
         }
         await Save();
-        NavigationManager.NavigateTo($"/present/{_questionSet?.Id}");
+        NavigationManager.NavigateTo($"/present/{_questionSet?.Id}{query_string}");
     }
 
     private async Task SaveAndContinue()

--- a/QuizExperiment.Admin/Client/Shared/Edit/SayWhatYouSeeQuestion.razor
+++ b/QuizExperiment.Admin/Client/Shared/Edit/SayWhatYouSeeQuestion.razor
@@ -1,0 +1,79 @@
+﻿@using QuizModels = QuizExperiment.Models
+@using System.Text.Json
+@inject HttpClient Http
+
+@if (Question is not null)
+{
+    var sayWhatYouSeeQuestion = Question as QuizModels.SayWhatYouSeeQuestion;
+    if (sayWhatYouSeeQuestion is not null)
+    {
+        // Ensure Answers is initialized
+        if (sayWhatYouSeeQuestion.Answers == null)
+        {
+            sayWhatYouSeeQuestion.Answers = new List<string>();
+        }
+        <CommonQuestion Question="Question" />
+        <div class="quiz-edit-question-answers-table-container flex-fill flex-grow-1">
+            <table class="table table-bordered quiz-edit-question-answers-table">
+                <thead>
+                    <tr>
+                        <th style="width: 90%">ANSWER</th>
+                        <th style="width: 10%"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @for (int i = 0; i < sayWhatYouSeeQuestion.Answers.Count; i++)
+                    {
+                        var answer = sayWhatYouSeeQuestion.Answers[i];
+                        var index = i; // capture the current value of i
+                        <tr>
+                            <td class="quiz-edit-question-answers-table-answer">
+                                <input type="text" class="form-control quiz-edit-question-input-answer"
+                                       placeholder="Possible answer..." required="required"
+                                       value="@answer"
+                                       @oninput="e => UpdateAnswer(index, e)" />
+                            </td>
+                            <td>
+                                <button type="button" class="btn btn-danger" title="Remove answer" @onclick="() => RemoveAnswer(index)">✕</button>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+            <button type="button" class="btn btn-primary" @onclick="AddAnswer">Add Answer</button>
+        </div>
+    }
+}
+
+@code {
+    [Parameter]
+    public QuizModels.Question? Question { get; set; }
+
+    private void AddAnswer()
+    {
+        if (Question is QuizModels.SayWhatYouSeeQuestion swysq)
+        {
+            if (swysq.Answers == null)
+                swysq.Answers = new List<string>();
+            swysq.Answers.Add("");
+            StateHasChanged();
+        }
+    }
+
+    private void RemoveAnswer(int index)
+    {
+        if (Question is QuizModels.SayWhatYouSeeQuestion swysq && swysq.Answers != null && index >= 0 && index < swysq.Answers.Count)
+        {
+            swysq.Answers.RemoveAt(index);
+            StateHasChanged();
+        }
+    }
+
+    private void UpdateAnswer(int index, ChangeEventArgs e)
+    {
+        if (Question is QuizModels.SayWhatYouSeeQuestion swysq && swysq.Answers != null && index >= 0 && index < swysq.Answers.Count)
+        {
+            swysq.Answers[index] = e.Value?.ToString() ?? string.Empty;
+        }
+    }
+}

--- a/QuizExperiment.Admin/Client/Shared/Present/QuestionAnswerChart.razor
+++ b/QuizExperiment.Admin/Client/Shared/Present/QuestionAnswerChart.razor
@@ -14,7 +14,12 @@
 
     var correctAnswerPercentage = ((int)Math.Round(totalAnswers > 0 ? (double)correctAnswerCount / totalAnswers * 100 : 0, 0)).ToString() + "%";
     var fastestUserId = UserAnswers?.Where(r => r.Value.Answer == correctAnswer).OrderBy(r => r.Value.TimeTaken).FirstOrDefault();
-    var fastestUser = Users[fastestUserId?.Key];
+    var fastestUser = "";
+    if (fastestUserId != null && fastestUserId?.Key != null && Users.ContainsKey(fastestUserId?.Key))
+    {
+        fastestUser = Users[fastestUserId?.Key];
+    }
+    
 
 }
 
@@ -25,19 +30,27 @@
         </button>
     </div>
     <div class="my-3 fs-4">The correct answer is</div>
-    <button class="btn btn-correct-answer btn-answer-@correctAnswerIndex" value="@correctButtonName"><span>@correctButtonName</span></button>
+    @if (!string.IsNullOrWhiteSpace(correctButtonName))
+    {
+        <button class="btn btn-correct-answer btn-answer-@correctAnswerIndex" value="@correctButtonName"><span>@correctButtonName</span></button>
+    }
+
     @if(string.Compare(correctButtonName, correctAnswerText, true) != 0)
     {
         <div class="my-3 fs-2 fw-bold">@correctAnswerText</div>
     }
 
     @{
-        <div class="my-3 fs-3 fw-bold">@correctAnswerPercentage of people got the correct answer</div>
-        if(fastestUserId != null)
+        if (fastestUserId != null && fastestUserId?.Key != null)
         {
+            <div class="my-3 fs-3 fw-bold">@correctAnswerPercentage of people got the correct answer</div>
             <div class="my-3 fs-3 fw-bold">🏎️@fastestUser was the fastest!🏁</div>
         }
-        
+        else
+        {
+            <div class="my-3 fs-3 fw-bold">No one got the correct answer</div>
+        }
+
     }
 
     

--- a/QuizExperiment.Admin/Client/Shared/Present/QuestionPicker.razor
+++ b/QuizExperiment.Admin/Client/Shared/Present/QuestionPicker.razor
@@ -15,6 +15,10 @@
         {
             <QuizExperiment.Admin.Client.Shared.Present.TrueFalseQuestion Question="@trueFalseQuestion" QuestionEndTime="@QuestionEndTime" UserAnswerCount="@UserAnswerCount" />
         }
+        else if (Question is QuizModels.SayWhatYouSeeQuestion sayWhatYouSeeQuestion)
+        {
+            <QuizExperiment.Admin.Client.Shared.Present.SayWhatYouSeeQuestion Question="@sayWhatYouSeeQuestion" QuestionEndTime="@QuestionEndTime" UserAnswerCount="@UserAnswerCount" />
+        }
         else
         {
             <p class="text-warning">Unsupported question type.</p>

--- a/QuizExperiment.Admin/Client/Shared/Present/SayWhatYouSeeQuestion.razor
+++ b/QuizExperiment.Admin/Client/Shared/Present/SayWhatYouSeeQuestion.razor
@@ -1,0 +1,31 @@
+@using QuizModels = QuizExperiment.Models
+
+@{
+    if(Question != null)
+    {
+        <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center quiz-page">
+            <div class="question-progress-container">
+                <div class="question-player-count">
+                    <div class="fs-4">PLAYERS ANSWERED</div>
+                    <div class="fs-4">@UserAnswerCount</div>
+                </div>
+                <CountDownTimer EndDate="@QuestionEndTime" />
+            </div>
+            <div class="question-container d-flex flex-column justify-content-center align-items-center">
+                <div class="quiz-admin-question-title my-3 fs-1 fw-bold px-3 text-center">@Question.Title</div>
+                <img class="img-fluid rounded img-quiz" src="@Question.ImageUrl" />
+            </div>
+        </div>
+    }
+}
+
+@code {
+    [Parameter]
+    public QuizModels.SayWhatYouSeeQuestion? Question { get; set; }
+
+    [Parameter]
+    public DateTime QuestionEndTime { get; set; }
+
+    [Parameter]
+    public int UserAnswerCount { get; set; }
+}

--- a/QuizExperiment.Admin/Client/wwwroot/css/app.css
+++ b/QuizExperiment.Admin/Client/wwwroot/css/app.css
@@ -1050,8 +1050,17 @@ nav.title-bar {
         margin-top:75px;
     }
 
+    .swys-container {
+        margin-top:0px;
+    }
+
     .multiple-choice-answer-text {
         font-size: x-small;
         height: 18px;
+    }
+
+    .img-quiz {
+        max-width: 360px;
+        margin-left: 0px;
     }
 }

--- a/QuizExperiment.Models.Test/Client/ClientQuestionSerializationTests.cs
+++ b/QuizExperiment.Models.Test/Client/ClientQuestionSerializationTests.cs
@@ -32,5 +32,44 @@ namespace QuizExperiment.Models.Test
             Assert.True(doc.RootElement.TryGetProperty("questionType", out _),
                     $"A question is missing the 'questionType' property: {question}");
         }
+
+        [Fact]
+        public void SayWhatYouSeeStringEqualityComparer_IsCaseInsensitive()
+        {
+            // Arrange
+            var comparer = new SayWhatYouSeeStringEqualityComparer();
+            var answer1 = "Hello World";
+            var answer2 = "hello world";
+
+            // Act
+            var areEqual = comparer.Equals(answer1, answer2);
+
+            // Assert
+            Assert.True(areEqual, "SayWhatYouSeeStringEqualityComparer should treat answers as equal regardless of case.");
+        }
+
+        [Fact]
+        public void ClientSayWhatYouSeeAnswer_Validation()
+        {
+
+            var answer1 = new ClientSayWhatYouSeeAnswer
+            {
+                Answers = new List<string>
+                {
+                    "one"
+                }
+            };
+
+            var answer2 = new ClientSayWhatYouSeeAnswer
+            {
+                Answers = new List<string>
+                {
+                    "One",
+                    "Two"
+                }
+            };
+
+            Assert.True(answer1 == answer2);
+        }
     }
 }

--- a/QuizExperiment.Models/Client/ClientAnswer.cs
+++ b/QuizExperiment.Models/Client/ClientAnswer.cs
@@ -9,6 +9,7 @@ namespace QuizExperiment.Models.Client
 {
     [JsonDerivedType(typeof(ClientMultipleChoiceAnswer), "multipleChoice")]
     [JsonDerivedType(typeof(ClientTrueFalseAnswer), "trueFalse")]
+    [JsonDerivedType(typeof(ClientSayWhatYouSeeAnswer), "sayWhatYouSee")]
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "anwserType")]
     public abstract class ClientAnswer : IEquatable<ClientAnswer>
     {

--- a/QuizExperiment.Models/Client/ClientQuestion.cs
+++ b/QuizExperiment.Models/Client/ClientQuestion.cs
@@ -12,6 +12,7 @@ namespace QuizExperiment.Models.Client
     /// </summary>
     [JsonDerivedType(typeof(ClientMultipleChoiceQuestion), "multipleChoice")]
     [JsonDerivedType(typeof(ClientTrueFalseQuestion), "trueFalse")]
+    [JsonDerivedType(typeof(ClientSayWhatYouSeeQuestion), "sayWhatYouSee")]
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "questionType")]
     public abstract class ClientQuestion
     {

--- a/QuizExperiment.Models/Client/ClientSayWhatYouSeeAnswer.cs
+++ b/QuizExperiment.Models/Client/ClientSayWhatYouSeeAnswer.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuizExperiment.Models.Client
+{
+    public class ClientSayWhatYouSeeAnswer : ClientAnswer, IEquatable<ClientSayWhatYouSeeAnswer>
+    {
+        [JsonPropertyName("answers")]
+        public List<string> Answers { get; set; } = new List<string>();
+
+        public override (string description, string index, string buttonName) GetAnswerDetails(ClientQuestion question)
+        {
+            var description = Answers[0];
+
+            if(Answers.Count > 1)
+            {
+                var otherAnswers = string.Join(" or ", Answers.Skip(1).Select(a => $"\"{a.ToLowerInvariant()}\""));
+                description += $" (also allowed {otherAnswers})";
+            }
+
+            return (description, "0", "");
+        }
+
+        public override bool Equals(ClientAnswer? other)
+        {
+            return Equals(other as ClientSayWhatYouSeeAnswer);
+        }
+
+        public bool Equals(ClientSayWhatYouSeeAnswer? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            // Return true if any item in either list matches any item in the other list (case-insensitive)
+            var comparer = new SayWhatYouSeeStringEqualityComparer();
+            return Answers.Any(a => other.Answers.Contains(a, comparer)) ||
+                   other.Answers.Any(a => Answers.Contains(a, comparer));
+        }
+
+        public static bool operator ==(ClientSayWhatYouSeeAnswer? left, ClientSayWhatYouSeeAnswer? right)
+        {
+            if (left is null && right is null) return true;
+            if (left is null || right is null) return false;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ClientSayWhatYouSeeAnswer? left, ClientSayWhatYouSeeAnswer? right)
+        {
+            return !(left == right);
+        }
+
+        public override int GetHashCode()
+        {
+            // Use case-insensitive hash code
+            return Answers
+                .Select(a => a?.ToLowerInvariant().GetHashCode() ?? 0)
+                .Aggregate(0, (current, hashCode) => current ^ hashCode);
+        }
+    }
+}

--- a/QuizExperiment.Models/Client/ClientSayWhatYouSeeQuestion.cs
+++ b/QuizExperiment.Models/Client/ClientSayWhatYouSeeQuestion.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizExperiment.Models.Client
+{
+    public class ClientSayWhatYouSeeQuestion : ClientQuestion
+    {
+    }
+}

--- a/QuizExperiment.Models/Client/SayWhatYouSeeStringEqualityComparer.cs
+++ b/QuizExperiment.Models/Client/SayWhatYouSeeStringEqualityComparer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuizExperiment.Models.Client
+{
+    public class SayWhatYouSeeStringEqualityComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string? x, string? y)
+        {
+            return string.Compare(x, y, true) == 0;
+        }
+
+        public int GetHashCode([DisallowNull] string obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/QuizExperiment.Models/PolymorphicQuestionConverter.cs
+++ b/QuizExperiment.Models/PolymorphicQuestionConverter.cs
@@ -19,6 +19,8 @@ namespace QuizExperiment.Models
                         return JsonSerializer.Deserialize<MultipleChoiceQuestion>(root.GetRawText(), options);
                     if (type == "trueFalse")
                         return JsonSerializer.Deserialize<TrueFalseQuestion>(root.GetRawText(), options);
+                    if (type == "sayWhatYouSee")
+                        return JsonSerializer.Deserialize<SayWhatYouSeeQuestion>(root.GetRawText(), options);
                 }
                 // Fallback: treat as MultipleChoiceQuestion (legacy)
                 return JsonSerializer.Deserialize<MultipleChoiceQuestion>(root.GetRawText(), options);
@@ -33,6 +35,8 @@ namespace QuizExperiment.Models
                 writer.WriteString("questionType", "multipleChoice");
             else if (value is TrueFalseQuestion)
                 writer.WriteString("questionType", "trueFalse");
+            else if (value is SayWhatYouSeeQuestion)
+                writer.WriteString("questionType", "sayWhatYouSee");
             // Write all other properties as named properties
             var type = value.GetType();
             foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))

--- a/QuizExperiment.Models/Question.cs
+++ b/QuizExperiment.Models/Question.cs
@@ -5,6 +5,7 @@ namespace QuizExperiment.Models
 {
     [JsonPolymorphic(TypeDiscriminatorPropertyName = "questionType")]
     [JsonDerivedType(typeof(MultipleChoiceQuestion), "multipleChoice")]
+    [JsonDerivedType(typeof(SayWhatYouSeeQuestion), "sayWhatYouSee")]
     [JsonDerivedType(typeof(TrueFalseQuestion), "trueFalse")]
     public abstract class Question
     {

--- a/QuizExperiment.Models/SayWhatYouSeeQuestion.cs
+++ b/QuizExperiment.Models/SayWhatYouSeeQuestion.cs
@@ -1,0 +1,34 @@
+﻿using QuizExperiment.Models.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace QuizExperiment.Models
+{
+    public class SayWhatYouSeeQuestion : Question
+    {
+        public List<string> Answers { get; set; } = new List<string>();
+
+        public override ClientAnswer GetCorrectAnswer()
+        {
+            return new ClientSayWhatYouSeeAnswer { Answers = this.Answers  };
+        }
+        public override ClientQuestion ToClientQuestion()
+        {
+            return new ClientSayWhatYouSeeQuestion
+            {
+                Title = "Say What You See",
+                ImageUrl = ImageUrl,
+            };
+        }
+
+        [JsonIgnore]
+        public override bool IsValid =>
+            !string.IsNullOrWhiteSpace(Title) &&
+            !string.IsNullOrWhiteSpace(ImageUrl) &&
+            Answers != null && Answers.Any(r => !string.IsNullOrWhiteSpace(r));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new question type, "Say What You See," to the quiz application. The changes span multiple files, implementing the new question type in both the client-side and server-side logic, as well as updating UI components and validation logic.

### Implementation of "Say What You See" Question Type:

* **Client-side Question and Answer Models:**
  - Added `ClientSayWhatYouSeeQuestion` and `ClientSayWhatYouSeeAnswer` as derived types in `ClientQuestion` and `ClientAnswer` respectively, enabling polymorphic serialization for the new question type. (`QuizExperiment.Models/Client/ClientAnswer.cs`, `QuizExperiment.Models/Client/ClientQuestion.cs`) [[1]](diffhunk://#diff-afb424a97b514973c70b7fbe71580594bf1da31c3605f45ca82206ea7a2a803bR12) [[2]](diffhunk://#diff-71982cf4336dea245fa684068d7c42882e0bc4e53b86cc9bc527983d2b5d2089R15)

* **UI Components for "Say What You See":**
  - Created `SayWhatYouSeeQuestion.razor` for displaying the question and capturing user input. Includes a text box for answers and a submit button. (`QuizExperiment.Admin/Client/Shared/Client/SayWhatYouSeeQuestion.razor`)
  - Added `SayWhatYouSeeQuestion` handling in `QuestionPicker.razor` for both client and presentation contexts, enabling dynamic rendering of the new question type. (`QuizExperiment.Admin/Client/Shared/Client/QuestionPicker.razor`, `QuizExperiment.Admin/Client/Shared/Present/QuestionPicker.razor`) [[1]](diffhunk://#diff-72ead59a482afcfb1bade834bfda95d2c20754c31bec5bbd6c14c7313faad25dR18-R21) [[2]](diffhunk://#diff-dd66706eca645b770b9fec1de6aa4c7a9eb4d7978f575352ad75cb6c6055329fR18-R21)
  - Implemented `SayWhatYouSeeQuestion.razor` for the presentation view, displaying the question title, image, and countdown timer. (`QuizExperiment.Admin/Client/Shared/Present/SayWhatYouSeeQuestion.razor`)

### Enhancements to Quiz Editing and Validation:

* **Question Type Picker Modal:**
  - Added a new button for selecting "Say What You See" questions in the modal, along with corresponding logic to handle the selection. (`QuizExperiment.Admin/Client/Shared/Edit/QuestionTypePickerModal.razor`) [[1]](diffhunk://#diff-d1231d5d1fc44fe6763f4fba649af9cc864b4aadd0c05d4e3a00f8f5682b8ea3R25-R30) [[2]](diffhunk://#diff-d1231d5d1fc44fe6763f4fba649af9cc864b4aadd0c05d4e3a00f8f5682b8ea3R58-R61)

* **Root Component Updates:**
  - Modified `OnAddQuestion` method to support creating "Say What You See" questions with default properties. (`QuizExperiment.Admin/Client/Shared/Edit/RootComponent.razor`)
  - Adjusted navigation logic to include folder paths when saving and presenting questions. (`QuizExperiment.Admin/Client/Shared/Edit/RootComponent.razor`)

### Testing and Validation:

* **Unit Tests:**
  - Added tests for case-insensitive comparison of answers and validation logic for `ClientSayWhatYouSeeAnswer`. (`QuizExperiment.Models.Test/Client/ClientQuestionSerializationTests.cs`)

### Miscellaneous:

* **Styling Updates:**
  - Added CSS classes for styling "Say What You See" components, including the image and container layout. (`QuizExperiment.Admin/Client/wwwroot/css/app.css`)

These changes collectively introduce a robust implementation of the "Say What You See" question type, ensuring compatibility across the quiz application while maintaining clean and modular code.

#49 